### PR TITLE
Updating Flask to autoload config settings from_object, as opposed to manually setting values by hand

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,9 +15,13 @@
 
 """Configuration for local development."""
 
+import os
 from secrets import *
 
 SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/test.db'
+
+SERVER_NAME = os.environ.get('SERVER_NAME', None)
+MAX_CONTENT_LENGTH = 16 * 1024 * 1024
 
 # Google OAuth2 login config for local development.
 GOOGLE_OAUTH2_EMAIL_ADDRESS = (

--- a/dpxdt/server/__init__.py
+++ b/dpxdt/server/__init__.py
@@ -32,23 +32,7 @@ import config
 
 
 app = Flask(__name__)
-
-app.config['SECRET_KEY'] = config.SECRET_KEY
-app.config['SERVER_NAME'] = os.environ.get('SERVER_NAME', None)
-
-app.config['CACHE_TYPE'] = config.CACHE_TYPE
-app.config['CACHE_DEFAULT_TIMEOUT'] = config.CACHE_DEFAULT_TIMEOUT
-
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
-
-app.config['REMEMBER_COOKIE_DOMAIN'] = config.SESSION_COOKIE_DOMAIN
-app.config['SESSION_COOKIE_DOMAIN'] = config.SESSION_COOKIE_DOMAIN
-
-app.config['SQLALCHEMY_DATABASE_URI'] = config.SQLALCHEMY_DATABASE_URI
-
-app.config['MAIL_DEFAULT_SENDER'] = config.MAIL_DEFAULT_SENDER
-app.config['MAIL_SUPPRESS_SEND'] = config.MAIL_SUPPRESS_SEND
-app.config['MAIL_USE_APPENGINE'] = config.MAIL_USE_APPENGINE
+app.config.from_object(config)
 
 
 db = SQLAlchemy(app)


### PR DESCRIPTION
For my (non-GAE) dpxdt install, I needed to configure a few additional flask_mail settings to get alerts working. In doing so, I noticed that the config definition / loading could be streamlined a little bit.
