### PR TITLE
Allow DB URI to be set via ENV

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@
 import os
 from secrets import *
 
-SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/test.db'
+SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI', 'sqlite:////tmp/test.db')
 
 SERVER_NAME = os.environ.get('SERVER_NAME', None)
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024


### PR DESCRIPTION
Allowing this to be more easily configured makes deploying this a lot easier, with better peace of mind as to persistence - as other databases and adapters can be used, or even just changing the db filepath to not be in `/tmp/`. I've kept the default as the same value.
