### PR TITLE
add --ssl-protocol=TLS1 to phantomjs invocation

### DIFF
--- a/dpxdt/client/capture_worker.py
+++ b/dpxdt/client/capture_worker.py
@@ -90,6 +90,7 @@ class CaptureWorkflow(process_worker.ProcessWorkflow):
             '--disk-cache=false',
             '--debug=true',
             '--ignore-ssl-errors=true',
+            '--ssl-protocol=TLSv1', # https://github.com/ariya/phantomjs/issues/11239
             FLAGS.phantomjs_script,
             self.config_path,
             self.output_path,


### PR DESCRIPTION
Without this change, sites over SSL don't work for me. I don't totally understand why this fixes my problem though. I guess certain SSL/TLS protocols in phantomjs are buggy, and this forces TLS1?

Alternatively, I'd be happy to add a flag that lets you pass custom flags to phantom on server start.
