### PR TITLE
TypeError in operations.py

### DIFF
--- a/dpxdt/server/operations.py
+++ b/dpxdt/server/operations.py
@@ -43,11 +43,13 @@ def _get_versioned_hash_key(key):
     versioned_key = '%s_version' % key
     version = int(time.time())
     if not cache.add(versioned_key, version):
-        version = cache.get(versioned_key)
-        if version is None:
+        val = cache.get(versioned_key)
+        if val is None:
             logging.error(
                 'Fetching cached version for %r returned None, using %d',
                 versioned_key, version)
+        else:
+            version = val
     return '%s:%d' % (key, version)
 
 


### PR DESCRIPTION
Occasionally a TypeError is thrown from the operations.py cache since version is set as None and falls through to the return statement. The formatting code then tries to convert None into a %d and throws the TypeError and then any subsequent request throw this error.

I'm not sure if it's because I'm using SQLite or if it's because the user is being logged out after a certain amount of time.

```
Traceback (most recent call last):
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/pivotal/workspace/dpxdt/dpxdt/server/auth.py", line 255, in wrapped
    g.build = can_user_access_build(param_name)
  File "/Users/pivotal/workspace/dpxdt/dpxdt/server/auth.py", line 200, in can_user_access_build
    ops = operations.UserOps(current_user.get_id())
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/werkzeug/local.py", line 338, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/werkzeug/local.py", line 297, in _get_current_object
    return self.__local()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_login.py", line 46, in <lambda>
    current_user = LocalProxy(lambda: _get_user())
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_login.py", line 794, in _get_user
    current_app.login_manager._load_user()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_login.py", line 363, in _load_user
    return self.reload_user()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_login.py", line 325, in reload_user
    user = self.user_callback(user_id)
  File "/Users/pivotal/workspace/dpxdt/dpxdt/server/auth.py", line 51, in load_user
    user = operations.UserOps(user_id).load()
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_cache/__init__.py", line 528, in decorated_function
    cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_cache/__init__.py", line 381, in make_cache_key
    timeout=_timeout)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_cache/__init__.py", line 336, in _memoize_version
    fname, instance_fname = function_namespace(f, args=args)
  File "/Users/pivotal/workspace/dpxdt/lib/python2.7/site-packages/flask_cache/__init__.py", line 56, in function_namespace
    instance_token = repr(args[0])
  File "/Users/pivotal/workspace/dpxdt/dpxdt/server/operations.py", line 69, in __repr__
    self.versioned_cache_key = _get_versioned_hash_key(self.cache_key)
  File "/Users/pivotal/workspace/dpxdt/dpxdt/server/operations.py", line 53, in _get_versioned_hash_key
    return '%s:%d' % (key, version)
TypeError: %d format: a number is required, not NoneType```