### PR TITLE
Do not throw NotReadyError for HTTP redirects

### DIFF
--- a/dpxdt/tools/local_pdiff.py
+++ b/dpxdt/tools/local_pdiff.py
@@ -331,7 +331,7 @@ class WaitForUrlWorkflowItem(workers.WorkflowItem):
         try:
             url = waitfor['url']
             r = requests.head(url)
-            if r.status_code != 200:
+            if r.status_code not in [200, 301, 302]:
                 yield heartbeat('Request for %s failed (%d)' % (url, r.status_code))
                 raise NotReadyError()
 

--- a/dpxdt/tools/local_pdiff.py
+++ b/dpxdt/tools/local_pdiff.py
@@ -330,8 +330,8 @@ class WaitForUrlWorkflowItem(workers.WorkflowItem):
 
         try:
             url = waitfor['url']
-            r = requests.head(url)
-            if r.status_code not in [200, 301, 302]:
+            r = requests.head(url, allow_redirects=True)
+            if r.status_code != 200:
                 yield heartbeat('Request for %s failed (%d)' % (url, r.status_code))
                 raise NotReadyError()
 


### PR DESCRIPTION
Correct me if I'm wrong but HTTP redirects should also be considered successful.