### PR TITLE
Handling of ``mailto:`` scheme in ``site_diff``

### DIFF
--- a/dpxdt/tools/site_diff.py
+++ b/dpxdt/tools/site_diff.py
@@ -67,13 +67,13 @@ gflags.DEFINE_spaceseplist(
 ABSOLUTE_URL_REGEX = r"(?P<url>(http(s?):)?//[^\"'> \t]+)"
 # URLs that are relative to the base of the current hostname.
 BASE_RELATIVE_URL_REGEX = (
-    r"/(?!(/)|(http(s?)://)|(url\())(?P<url>[^\"'> \t]*)")
+    r"/(?!(/)|(mailto:)|(http(s?)://)|(url\())(?P<url>[^\"'> \t]*)")
 # URLs that have '../' or './' to start off their paths.
 TRAVERSAL_URL_REGEX = (
     r"(?P<relative>\.(\.)?)/(?!(/)|"
     r"(http(s?)://)|(url\())(?P<url>[^\"'> \t]*)")
 # URLs that are in the same directory as the requested URL.
-SAME_DIR_URL_REGEX = r"(?!(/)|(http(s?)://)|(#)|(url\())(?P<url>[^\"'> \t]+)"
+SAME_DIR_URL_REGEX = r"(?!(/)|(mailto:)|(http(s?)://)|(#)|(url\())(?P<url>[^\"'> \t]+)"
 # URL matches the root directory.
 ROOT_DIR_URL_REGEX = r"(?!//(?!>))/(?P<url>)(?=[ \t\n]*[\"'> /])"
 # Start of a tag using 'src' or 'href'

--- a/tests/site_diff_test.py
+++ b/tests/site_diff_test.py
@@ -337,14 +337,12 @@ class HtmlRewritingTest(unittest.TestCase):
             test('http://www.example.com/relative-with/some-'
                  '(parenthesis%20here)'))
 
+        self.assertIsNone(test('mailto:bob@example.com'))
+
         # Known bad results
         self.assertEquals(
             'http://www.example.com/my-url/ftp://bob@www.example.com/',
             test('ftp://bob@www.example.com/'))
-
-        self.assertEquals(
-            'http://www.example.com/my-url/mailto:bob@example.com',
-            test('mailto:bob@example.com'))
 
         self.assertEquals(
             'http://www.example.com/my-url/javascript:runme()',


### PR DESCRIPTION
This is a proposal to fix this particular ``mailto:``case which was annoying to us.
Just to be clear: "known bad results" in the unit tests meant that it needed to be fixed, right?