### PR TITLE
Add config.readyEvent and config.delay

### DIFF
--- a/dpxdt/client/capture.js
+++ b/dpxdt/client/capture.js
@@ -237,9 +237,18 @@ page.onLoadFinished = function(status) {
 
 // Takes the screenshot and exits successfully.
 page.doScreenshot = function() {
-    console.log('Taking the screenshot and saving to:', outputPath);
-    page.render(outputPath);
-    phantom.exit(0);
+    if (config.delay) {
+        setTimeout(function() {
+            console.log('Taking the screenshot and saving to:', outputPath);
+            page.render(outputPath);
+            phantom.exit(0);
+        }, config.delay);
+    }
+    else {
+        console.log('Taking the screenshot and saving to:', outputPath);
+        page.render(outputPath);
+        phantom.exit(0);
+    }
 };
 
 


### PR DESCRIPTION
If `config.readyEvent` is set, `phantomjs` will wait for exactly this `console.log` message
before taking a screenshot.

`config.delay` is applied before taling a screenshot (after `readyEvent` if it's set).

So with config
```json
{
  ...
  "readyEvent": "captureScreen",
  "delay": 1000
}
```
`phantomjs` will wait for one second after the string `captureScreen` is logged to the console.

Both features are from [BackstopJS](https://github.com/garris/BackstopJS#trigger-screen-capture-via-consolelog).

Fixes #123.