### PR TITLE
Deployment scripts for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ dist
 bin
 include
 lib
+Scripts
 pip-selfcheck.json

--- a/deployment/sqlite/run.cmd
+++ b/deployment/sqlite/run.cmd
@@ -1,0 +1,8 @@
+call Scripts/activate.bat
+pip install -r requirements.txt
+pip install -e .
+
+set YOURAPPLICATION_SETTINGS=../../settings.cfg
+set SQLITE_PRODUCTION=Yes
+
+dpxdt_server --flagfile=flags.cfg

--- a/deployment/sqlite_deploy.cmd
+++ b/deployment/sqlite_deploy.cmd
@@ -1,0 +1,13 @@
+rmdir sqlite_deploy /s /q
+robocopy sqlite sqlite_deploy /e
+cd sqlite_deploy
+
+rem symlinks are replaced by text files, we should copy destination files manually
+del /q /f dpxdt requirements.txt setup.py
+robocopy ..\..\dpxdt dpxdt /e
+copy ..\..\requirements.txt requirements.txt
+copy ..\..\setup.py setup.py
+
+python bootstrap.py
+del /q /f bootstrap.py
+cd ..


### PR DESCRIPTION
There are no `make` or `bash` on windows, so now users have to do all this manually.