### PR TITLE
Implements capture.py (using webdriver/browserstack)

### DIFF
--- a/dpxdt/client/capture.py
+++ b/dpxdt/client/capture.py
@@ -1,0 +1,54 @@
+#!/usr/local/bin/python
+
+# Copyright 2016 Lindsey Simon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a version of capture written to work with webdriver.
+# Specifically, I've been testing with BrowserStack.
+# Its configuration expectations are quite different from capture.js
+# which is written for phantomjs.
+
+# TODO(elsigh): Support cookies
+# TODO(elsigh): Support resourcesToIgnore
+# TODO(elsigh): Support httpUserName/httpPassWord
+# TODO(elsigh): Support userAgent
+# TODO(elsigh): Support injectCSS/injectJS
+
+import json
+import logging
+from pprint import pprint
+import sys
+import time
+from selenium import webdriver
+
+config_file_path = sys.argv[1]
+output_file = sys.argv[2]
+
+with open(config_file_path) as config_file:
+    config = json.load(config_file)
+print "config: "
+pprint(config)
+
+assert config['command_executor']
+command_executor = config['command_executor']
+assert config['desired_capabilities']
+desired_capabilities = config['desired_capabilities']
+assert config['targetUrl']
+target_url = config['targetUrl']
+
+
+driver = webdriver.Remote(
+    command_executor=config['command_executor'],
+    desired_capabilities=config['desired_capabilities'],
+)
+driver.get(config['targetUrl'])
+driver.save_screenshot(output_file)
+driver.quit()

--- a/dpxdt/tools/flags.py
+++ b/dpxdt/tools/flags.py
@@ -67,3 +67,10 @@ gflags.DEFINE_string(
     'http_password', None,
     'Password if site is protected by an HTTP basic authentication')
 
+gflags.DEFINE_string(
+    'command_executor', None,
+    'Webdriver.Remote command_executor argument')
+
+gflags.DEFINE_string(
+    'desired_capabilities', None,
+    'webdriver.Remote desired_capabilities argument')

--- a/dpxdt/tools/url_pair_diff.py
+++ b/dpxdt/tools/url_pair_diff.py
@@ -100,6 +100,13 @@ class UrlPairDiff(workers.WorkflowItem):
         if FLAGS.http_password:
             config_dict['httpPassword'] = FLAGS.http_password
 
+        if FLAGS.command_executor:
+            config_dict['command_executor'] = FLAGS.command_executor
+
+        if FLAGS.desired_capabilities:
+            config_dict['desired_capabilities'] = json.loads(
+                FLAGS.desired_capabilities)
+
         config_data = json.dumps(config_dict)
 
         url_parts = urlparse.urlparse(new_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ poster==0.8.1
 pyimgur==0.5.2
 python-gflags==2.0
 requests==2.5.1
+selenium==2.53.6
 watchdog==0.8.3
 wsgiref==0.1.2

--- a/run_combined.sh
+++ b/run_combined.sh
@@ -3,7 +3,9 @@
 ./dpxdt/tools/run_server.py \
     --enable_api_server \
     --enable_queue_workers \
-    --phantomjs_timeout=20 \
+    --capture_timeout=60 \
+    --capture_binary=python \
+    --capture_script=/Users/elsigh/src/dpxdt/dpxdt/client/capture.py \
     --release_server_prefix=http://localhost:5000/api \
     --queue_server_prefix=http://localhost:5000/api/work_queue \
     --queue_idle_poll_seconds=10 \


### PR DESCRIPTION
Starts deprecating `phantomjs` flags in favor of more general `capture` flags. 
Tested this with `run_combined.sh` using a `--capture_binary=python` and `capture_script` pointing to `capture.py` then called `run_url_pair_diff.sh` with `command_executor` and `desired_capabilities` args. Screenshots were loaded from Browserstack and worked great.

Still more testing to do, so for now nothing really changes for anyone with this diff, but if things go well, will at least write a README section about using BrowserStack instead of phantomjs.