### PR TITLE
Adds a workflow process to remove the alpha channel before pdiff

### DIFF
--- a/dpxdt/client/process_worker.py
+++ b/dpxdt/client/process_worker.py
@@ -36,6 +36,7 @@ LOGGER = workers.LOGGER
 class Error(Exception):
     """Base class for exceptions in this module."""
 
+
 class TimeoutError(Exception):
     """Subprocess has taken too long to complete and was terminated."""
 


### PR DESCRIPTION
pdiff often produces lousy diffs based on the fact that it can't handle alpha transparency correctly. Trying this to see if it will improve things