### PR TITLE
Revert "Merge pull request #183 from bslatkin/convert-alpha"

### DIFF
--- a/dpxdt/client/pdiff_worker.py
+++ b/dpxdt/client/pdiff_worker.py
@@ -57,10 +57,6 @@ gflags.DEFINE_string(
     'pdiff_composite_binary', 'composite',
     'Path to the composite binary used for resizing images.')
 
-gflags.DEFINE_string(
-    'pdiff_convert_binary', 'convert',
-    'Path to the convert binary used for removing alpha from images.')
-
 gflags.DEFINE_integer(
     'pdiff_threads', 1, 'Number of perceptual diff threads to run')
 
@@ -103,35 +99,6 @@ class ResizeWorkflow(process_worker.ProcessWorkflow):
             self.ref_path,
             self.run_path,
             self.resized_ref_path,
-        ]
-
-
-class ConvertAlphaWorkflow(process_worker.ProcessWorkflow):
-    """Workflow for converting alpha out of images before pdiff."""
-
-    def __init__(self, log_path, ref_path, output_path):
-        """Initializer.
-
-        Args:
-            log_path: Where to write the verbose logging output.
-            ref_path: Path to reference screenshot to convert.
-            output_path: Where the converted ref image should be written.
-        """
-        process_worker.ProcessWorkflow.__init__(
-            self, log_path, timeout_seconds=FLAGS.pdiff_timeout)
-        self.ref_path = ref_path
-        self.output_path = output_path
-
-    def get_args(self):
-        # Method from http://www.imagemagick.org/Usage/convert/
-        return [
-            FLAGS.pdiff_convert_binary,
-            '-background',
-            'white',
-            '-alpha',
-            'remove',
-            self.ref_path,
-            self.output_path,
         ]
 
 
@@ -193,7 +160,6 @@ class DoPdiffQueueWorkflow(workers.WorkflowItem):
         try:
             ref_path = os.path.join(output_path, 'ref')
             ref_resized_path = os.path.join(output_path, 'ref_resized')
-            ref_converted_path = os.path.join(output_path, 'ref_converted')
             run_path = os.path.join(output_path, 'run')
             diff_path = os.path.join(output_path, 'diff.png')
             log_path = os.path.join(output_path, 'log.txt')
@@ -216,17 +182,9 @@ class DoPdiffQueueWorkflow(workers.WorkflowItem):
                     max_attempts,
                     'Could not resize reference image to size of new image')
 
-            yield heartbeat('Removing alpha channel from reference image')
-            returncode = yield ConvertAlphaWorkflow(
-                log_path, ref_resized_path, ref_converted_path)
-            if returncode != 0:
-                raise PdiffFailedError(
-                    max_attempts,
-                    'Could not convert reference image (remove alpha)')
-
             yield heartbeat('Running perceptual diff process')
             returncode = yield PdiffWorkflow(
-                log_path, ref_converted_path, run_path, diff_path)
+                log_path, ref_resized_path, run_path, diff_path)
 
             # ImageMagick returns 1 if the images are different and 0 if
             # they are the same, so the return code is a bad judge of

--- a/dpxdt/client/process_worker.py
+++ b/dpxdt/client/process_worker.py
@@ -36,7 +36,6 @@ LOGGER = workers.LOGGER
 class Error(Exception):
     """Base class for exceptions in this module."""
 
-
 class TimeoutError(Exception):
     """Subprocess has taken too long to complete and was terminated."""
 


### PR DESCRIPTION
This reverts commit 9f0f31ba3c120a0c29fc6762f5ec44a707ca97db, reversing
changes made to 6768269c9c4d2ad85055f4980bfd280b4528e0ac.

I'm not sure how to do this properly, but I assume that if the test is failing that I did it wrong.
I'm trying to figure out how to get rid of alpha channel artifacts.