### PR TITLE
Support per-host custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,9 @@ The config passed to the `request_run` function may have any or all of these fie
     "httpPassword": "my-password",
     "injectCss": ".my-css-rules-here { display: none; }",
     "injectJs": "document.getElementById('foobar').innerText = 'foo';",
+    "injectHeaders": {
+        "domain.com": { "X-CustomHeader": "HeaderValue" }
+    },
     "resourcesToIgnore": ["www.google-analytics.com", "bad.example.com"],
     "resourceTimeoutMs": 60000,
     "userAgent": "My fancy user agent",

--- a/dpxdt/client/capture.js
+++ b/dpxdt/client/capture.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// TODO: Header key/value pairs
 // TODO: User agent spoofing shortcut
 
 var fs = require('fs');

--- a/dpxdt/client/capture.js
+++ b/dpxdt/client/capture.js
@@ -131,6 +131,18 @@ page.onResourceRequested = function(requestData, networkRequest) {
                 return;
             }
         }
+
+        if (config.injectHeaders) {
+            for (var host in config.injectHeaders) {
+                if (host == url || url.match(new RegExp(host))) {
+                    var headers = config.injectHeaders[host];
+                    for (var header in headers) {
+                        networkRequest.setHeader(header, headers[header]);
+                        console.log('Setting header ' + header + ' to ' + headers[header]);
+                    }
+                }
+            }
+        }
         console.log('Requested: ' + url);
     }
 

--- a/dpxdt/client/capture.py
+++ b/dpxdt/client/capture.py
@@ -19,6 +19,7 @@
 # TODO(elsigh): Support cookies
 # TODO(elsigh): Support resourcesToIgnore
 # TODO(elsigh): Support httpUserName/httpPassWord
+# TODO(elsigh): Support injectHeaders
 
 import json
 import logging


### PR DESCRIPTION
This adds support for custom, per-host headers, and fixes #191.
The new config stanza looks like:

```yaml
injectHeaders:
  hostpattern:
    X-FirstHeader: FirstValue
    X-OtherHeader: SomeOtherValue
    Host: fakehostname.com
```

All connections to a host matching `hostpattern` (using the same methodology as `resourcesToIgnore`, matching on exact string, or regexp syntax search) have those headers added.
I tested this locally and it works perfectly, but it was not clear how to add this cleanly to the test suite.