### PR TITLE
Fix request hang

### DIFF
--- a/dpxdt/tools/run_server.py
+++ b/dpxdt/tools/run_server.py
@@ -107,7 +107,8 @@ def main(block=True):
             server.app.run(
                 debug=FLAGS.reload_code,
                 host=FLAGS.host,
-                port=FLAGS.port)
+                port=FLAGS.port,
+                threaded=server.utils.is_production())
         elif FLAGS.enable_queue_workers:
             coordinator.join()
         else:


### PR DESCRIPTION
Run multithreaded server when in production.

I've encountered hanging of both API requests and web interface. It went away when I activated threading.